### PR TITLE
Fix missing else branch in CheckBirthday.php

### DIFF
--- a/modules/usrmgr/Functions/CheckBirthday.php
+++ b/modules/usrmgr/Functions/CheckBirthday.php
@@ -20,5 +20,7 @@ function check_birthday($date): bool|string
         } else {
             return false;
         }
+    } else {
+        return false;
     }
 }


### PR DESCRIPTION
Function returns null without else branch, which is not allowed.

### What is this PR doing?

<!--
Please describe what you add, change, or fix in this PR.
This is a useful place to

- bug: add how to reproduce it
- explain your design decisions/thoughts
-->
Adds an `else` branch in `CheckBirthday()` to avoid fatal error.

### Which issue(s) this PR fixes:

Fixes #718

### Checklist

- [ ] `CHANGELOG.md` entry
- [ ] Documentation update